### PR TITLE
headTemplate options should be relative to the caller

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var defaults = {
   dependencies: [],
   transform: [],
   quoteChar: '\'',
-  headTemplate: 'templates/head.js',
+  headTemplate: path.join(__dirname, 'templates/head.js'),
   requireDepFunctionName: '_requireDep',
   oldHeadLengthNoExports: 270
 };
@@ -115,7 +115,7 @@ function bundle(options, cb) {
       return cb(err);
     }
 
-    var templatePath = path.join(__dirname, options.headTemplate);
+    var templatePath = options.headTemplate;
     fs.readFile(templatePath, function(err, template) {
       if (err) {
         return cb(err);


### PR DESCRIPTION
Previously you had to pass the headTemplate path relative to where
cjs-umd was installed to rather than where you were defining your
options hash. To reference "/templates", you had to pass "../../templates"
and that's assuming it was installed as a primary dependency and not
a dependency of a dependency.
